### PR TITLE
Add script for conversion to BIDS #8

### DIFF
--- a/bids_conversion.py
+++ b/bids_conversion.py
@@ -1,0 +1,89 @@
+import os
+import shutil
+import glob
+
+
+# This script should be run from the directory containing the input sites directories
+project_root = './'
+
+sites = ["MGH", "MNI"]
+subjects = ["SubD", "SubL", "SubR", "Spinoza6"]
+
+
+def copy_scan(input_path, output_path):
+    nii_path = input_path
+    json_path = input_path.replace(".nii.gz", ".json")
+    shutil.copy2(nii_path, output_path + ".nii.gz")
+    shutil.copy2(json_path, output_path + ".json")
+
+
+# Output directories are all generated in the outputs folder
+output_path_root = os.path.join(project_root, "outputs")
+if os.path.exists(output_path_root): shutil.rmtree(output_path_root)
+os.makedirs(output_path_root)
+
+for site in sites:
+    # Output directories are all generated in the outputs folder
+    site_output_path = os.path.join(output_path_root, site)
+
+    for subject in subjects:
+        # Input directories are named SITE-original, for example "MGH-original"
+        input_path = os.path.join(project_root, site + "-original", subject)
+        assert(os.path.exists(input_path))
+
+        output_path = os.path.join(site_output_path, subject)
+
+        output_anat_path = os.path.join(output_path, "anat")
+        output_fmap_path = os.path.join(output_path, "fmap")
+        os.makedirs(output_anat_path)
+        os.makedirs(output_fmap_path)
+
+        for dir_path in [dir[0] for dir in os.walk(input_path)]:
+            dir_basename = os.path.basename(dir_path)
+
+            if dir_basename == "COILQA_SAG_LARGE":
+                snr_input_path = sorted(glob.glob(os.path.join(dir_path, "*.nii.gz")))[1]
+                copy_scan(snr_input_path, os.path.join(output_fmap_path, subject + "_coilqa-sag-large-SNR"))
+
+            elif dir_basename == "COILQA_SAG_SMALL":
+                gfactor_input_path = sorted(glob.glob(os.path.join(dir_path, "*nii.gz")))[0]
+                copy_scan(gfactor_input_path, os.path.join(output_fmap_path, subject + "_coilqa-sag-small-GFactor"))
+
+            elif dir_basename == "COILQA_TRA":
+                gfactor_input_path = sorted(glob.glob(os.path.join(dir_path, "*nii.gz")))[0]
+                copy_scan(gfactor_input_path, os.path.join(output_fmap_path, subject + "_coilqa-tra-GFactor"))
+
+            elif dir_basename in ["DREAM_MEDIUM", "DREAM_MEDIUM_066", "DREAM_MEDIUM_HWLIMIT"]:
+                dream_file_paths = sorted(glob.glob(os.path.join(dir_path, "*nii.gz")))
+                for dream_file_path in dream_file_paths:
+                    dream_filename_tokens = os.path.basename(dream_file_path).split("_")
+                    eVer = dream_filename_tokens[-1].split(".")[0]
+                    series_number = dream_filename_tokens[0]
+                    scan_type = dir_basename.lower().replace("_", "-")
+                    copy_scan(dream_file_path, os.path.join(output_fmap_path, subject + "_" + scan_type + "-" + eVer + "-" + series_number))
+
+            elif dir_basename == "GRE":
+                gre_file_paths = sorted(glob.glob(os.path.join(dir_path, "*nii.gz")))
+                for gre_file_path in gre_file_paths:
+                    gre_filename = os.path.basename(gre_file_path)
+                    gre_filename_tokens = gre_filename.split("_")
+                    if "RX" in gre_filename:
+                        channel_name = gre_filename_tokens[5].split(".")[0]
+                        if ("ph" in gre_filename_tokens[-1]): channel_name += "-ph"
+                        copy_scan(gre_file_path, os.path.join(output_anat_path, subject + "_gre-uncombined-" + channel_name + "_T2starw"))
+                    else:
+                        series_number = gre_filename_tokens[0]
+                        copy_scan(gre_file_path, os.path.join(output_anat_path, subject + "_gre_combined-" + series_number + "_T2starw"))
+
+            elif dir_basename == "MP2RAGE":
+                mp2rage_file_paths = sorted(glob.glob(os.path.join(dir_path, "*nii.gz")))
+                mp2rage_types = ["INV1", "INV2", "UNI"]
+                for i in range(len(mp2rage_file_paths)):
+                    copy_scan(mp2rage_file_paths[i], os.path.join(output_anat_path, subject + "_mp2rage-" + mp2rage_types[i]))
+
+            elif dir_basename == "TFL_B1_C3C4":
+                tfl_file_paths = sorted(glob.glob(os.path.join(dir_path, "*nii.gz")))
+                copy_scan(tfl_file_paths[0], os.path.join(output_fmap_path, subject + "_tfl-mag"))
+                copy_scan(tfl_file_paths[2], os.path.join(output_fmap_path, subject + "_tfl-FAmap"))
+
+


### PR DESCRIPTION
This script converts the existing data for MGH and MNI scans from the previous structure/format to BIDS.
![Screenshot 2023-12-27 130852](https://github.com/spinal-cord-7t/coil-qc-code/assets/56048818/3aeb6214-7cbc-4210-a523-279fc659db4a)
In order to use it, first download the archives from the OSF repository, unzip them and rename them to `SITE-original`. Then run the `bids_conversion.py` script from this directory. It will generate a folder called `outputs`, which has the following directory structure:
```
├───MGH
│   ├───Spinoza6
│   │   ├───anat
│   │   └───fmap
│   ├───SubD
│   │   ├───anat
│   │   └───fmap
│   ├───SubL
│   │   ├───anat
│   │   └───fmap
│   └───SubR
│       ├───anat
│       └───fmap
└───MNI
    ├───Spinoza6
    │   ├───anat
    │   └───fmap
    ├───SubD
    │   ├───anat
    │   └───fmap
    ├───SubL
    │   ├───anat
    │   └───fmap
    └───SubR
        ├───anat
        └───fmap
```
This is an example of the `tree` output for `MGH/SubD`:
```
├───anat
│       SubD_gre-uncombined-cRX01-ph_T2starw.json
│       SubD_gre-uncombined-cRX01-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX01_T2starw.json
│       SubD_gre-uncombined-cRX01_T2starw.nii.gz
│       SubD_gre-uncombined-cRX02-ph_T2starw.json
│       SubD_gre-uncombined-cRX02-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX02_T2starw.json
│       SubD_gre-uncombined-cRX02_T2starw.nii.gz
│       SubD_gre-uncombined-cRX03-ph_T2starw.json
│       SubD_gre-uncombined-cRX03-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX03_T2starw.json
│       SubD_gre-uncombined-cRX03_T2starw.nii.gz
│       SubD_gre-uncombined-cRX04-ph_T2starw.json
│       SubD_gre-uncombined-cRX04-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX04_T2starw.json
│       SubD_gre-uncombined-cRX04_T2starw.nii.gz
│       SubD_gre-uncombined-cRX05-ph_T2starw.json
│       SubD_gre-uncombined-cRX05-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX05_T2starw.json
│       SubD_gre-uncombined-cRX05_T2starw.nii.gz
│       SubD_gre-uncombined-cRX06-ph_T2starw.json
│       SubD_gre-uncombined-cRX06-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX06_T2starw.json
│       SubD_gre-uncombined-cRX06_T2starw.nii.gz
│       SubD_gre-uncombined-cRX07-ph_T2starw.json
│       SubD_gre-uncombined-cRX07-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX07_T2starw.json
│       SubD_gre-uncombined-cRX07_T2starw.nii.gz
│       SubD_gre-uncombined-cRX08-ph_T2starw.json
│       SubD_gre-uncombined-cRX08-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX08_T2starw.json
│       SubD_gre-uncombined-cRX08_T2starw.nii.gz
│       SubD_gre-uncombined-cRX09-ph_T2starw.json
│       SubD_gre-uncombined-cRX09-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX09_T2starw.json
│       SubD_gre-uncombined-cRX09_T2starw.nii.gz
│       SubD_gre-uncombined-cRX10-ph_T2starw.json
│       SubD_gre-uncombined-cRX10-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX10_T2starw.json
│       SubD_gre-uncombined-cRX10_T2starw.nii.gz
│       SubD_gre-uncombined-cRX11-ph_T2starw.json
│       SubD_gre-uncombined-cRX11-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX11_T2starw.json
│       SubD_gre-uncombined-cRX11_T2starw.nii.gz
│       SubD_gre-uncombined-cRX12-ph_T2starw.json
│       SubD_gre-uncombined-cRX12-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX12_T2starw.json
│       SubD_gre-uncombined-cRX12_T2starw.nii.gz
│       SubD_gre-uncombined-cRX13-ph_T2starw.json
│       SubD_gre-uncombined-cRX13-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX13_T2starw.json
│       SubD_gre-uncombined-cRX13_T2starw.nii.gz
│       SubD_gre-uncombined-cRX14-ph_T2starw.json
│       SubD_gre-uncombined-cRX14-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX14_T2starw.json
│       SubD_gre-uncombined-cRX14_T2starw.nii.gz
│       SubD_gre-uncombined-cRX15-ph_T2starw.json
│       SubD_gre-uncombined-cRX15-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX15_T2starw.json
│       SubD_gre-uncombined-cRX15_T2starw.nii.gz
│       SubD_gre-uncombined-cRX16-ph_T2starw.json
│       SubD_gre-uncombined-cRX16-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX16_T2starw.json
│       SubD_gre-uncombined-cRX16_T2starw.nii.gz
│       SubD_gre-uncombined-cRX17-ph_T2starw.json
│       SubD_gre-uncombined-cRX17-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX17_T2starw.json
│       SubD_gre-uncombined-cRX17_T2starw.nii.gz
│       SubD_gre-uncombined-cRX18-ph_T2starw.json
│       SubD_gre-uncombined-cRX18-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX18_T2starw.json
│       SubD_gre-uncombined-cRX18_T2starw.nii.gz
│       SubD_gre-uncombined-cRX19-ph_T2starw.json
│       SubD_gre-uncombined-cRX19-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX19_T2starw.json
│       SubD_gre-uncombined-cRX19_T2starw.nii.gz
│       SubD_gre-uncombined-cRX20-ph_T2starw.json
│       SubD_gre-uncombined-cRX20-ph_T2starw.nii.gz
│       SubD_gre-uncombined-cRX20_T2starw.json
│       SubD_gre-uncombined-cRX20_T2starw.nii.gz
│       SubD_gre_combined-64_T2starw.json
│       SubD_gre_combined-64_T2starw.nii.gz
│       SubD_gre_combined-66_T2starw.json
│       SubD_gre_combined-66_T2starw.nii.gz
│       SubD_gre_combined-67_T2starw.json
│       SubD_gre_combined-67_T2starw.nii.gz
│       SubD_gre_combined-68_T2starw.json
│       SubD_gre_combined-68_T2starw.nii.gz
│       SubD_mp2rage-INV1.json
│       SubD_mp2rage-INV1.nii.gz
│       SubD_mp2rage-INV2.json
│       SubD_mp2rage-INV2.nii.gz
│       SubD_mp2rage-UNI.json
│       SubD_mp2rage-UNI.nii.gz
│
└───fmap
        SubD_coilqa-sag-large-SNR.json
        SubD_coilqa-sag-large-SNR.nii.gz
        SubD_coilqa-sag-small-GFactor.json
        SubD_coilqa-sag-small-GFactor.nii.gz
        SubD_coilqa-tra-GFactor.json
        SubD_coilqa-tra-GFactor.nii.gz
        SubD_dream-medium-066-e1-39.json
        SubD_dream-medium-066-e1-39.nii.gz
        SubD_dream-medium-066-e1-42.json
        SubD_dream-medium-066-e1-42.nii.gz
        SubD_dream-medium-066-e2-39.json
        SubD_dream-medium-066-e2-39.nii.gz
        SubD_dream-medium-066-e2-40.json
        SubD_dream-medium-066-e2-40.nii.gz
        SubD_dream-medium-066-e2-41.json
        SubD_dream-medium-066-e2-41.nii.gz
        SubD_dream-medium-066-e2-42.json
        SubD_dream-medium-066-e2-42.nii.gz
        SubD_dream-medium-066-e2-43.json
        SubD_dream-medium-066-e2-43.nii.gz
        SubD_dream-medium-066-e2-44.json
        SubD_dream-medium-066-e2-44.nii.gz
        SubD_dream-medium-e1-33.json
        SubD_dream-medium-e1-33.nii.gz
        SubD_dream-medium-e1-36.json
        SubD_dream-medium-e1-36.nii.gz
        SubD_dream-medium-e2-33.json
        SubD_dream-medium-e2-33.nii.gz
        SubD_dream-medium-e2-34.json
        SubD_dream-medium-e2-34.nii.gz
        SubD_dream-medium-e2-35.json
        SubD_dream-medium-e2-35.nii.gz
        SubD_dream-medium-e2-36.json
        SubD_dream-medium-e2-36.nii.gz
        SubD_dream-medium-e2-37.json
        SubD_dream-medium-e2-37.nii.gz
        SubD_dream-medium-e2-38.json
        SubD_dream-medium-e2-38.nii.gz
        SubD_dream-medium-hwlimit-e1-45.json
        SubD_dream-medium-hwlimit-e1-45.nii.gz
        SubD_dream-medium-hwlimit-e1-48.json
        SubD_dream-medium-hwlimit-e1-48.nii.gz
        SubD_dream-medium-hwlimit-e2-45.json
        SubD_dream-medium-hwlimit-e2-45.nii.gz
        SubD_dream-medium-hwlimit-e2-46.json
        SubD_dream-medium-hwlimit-e2-46.nii.gz
        SubD_dream-medium-hwlimit-e2-47.json
        SubD_dream-medium-hwlimit-e2-47.nii.gz
        SubD_dream-medium-hwlimit-e2-48.json
        SubD_dream-medium-hwlimit-e2-48.nii.gz
        SubD_dream-medium-hwlimit-e2-49.json
        SubD_dream-medium-hwlimit-e2-49.nii.gz
        SubD_dream-medium-hwlimit-e2-50.json
        SubD_dream-medium-hwlimit-e2-50.nii.gz
        SubD_tfl-FAmap.json
        SubD_tfl-FAmap.nii.gz
        SubD_tfl-mag.json
        SubD_tfl-mag.nii.gz
```
I followed the general instructions detailed in #8 to figure out in which directory (`fmap` or `anat`) to place each file, but did not know how to name every file. I thus named them so that it clearly states the relevant information that distinguishes each file, and added the series number when I wasn't sure what exactly differentiates them (for example, for the GRE combined scans or the DREAM scans). For the DREAM scans for which we were not sure which ones to include/exclude, I simply included all of them as a first step, but it will be easy to modify this as needed. Now that the script is written, it is very easy to rename these files correctly so they follow the BIDS convention.

I would appreciate guidance concerning what the correct naming convention should be for these files. I have uploaded the generated outputs from this first version of the script in [NeuroPoly/Projects/Spine7T_Zurich/Data/outputs_2023-12-27.zip](https://drive.google.com/file/d/1jz2PcQLY4HXbFfYv4HFBje6gzsqeKa5U/view?usp=sharing).