### PR TITLE
turboFLASH B1+ visualization

### DIFF
--- a/data_processing.ipynb
+++ b/data_processing.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3d6cf6bf",
+   "id": "8a81e9fa",
    "metadata": {},
    "source": [
     "## Setup"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70a2c317",
+   "id": "a29b5300",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,6 +29,8 @@
     "import shutil\n",
     "import gdown\n",
     "import zipfile\n",
+    "from scipy.interpolate import interp1d\n",
+    "from scipy.ndimage import uniform_filter1d\n",
     "\n",
     "%matplotlib inline"
    ]
@@ -36,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "498e333b",
+   "id": "038ad0b3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,7 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c2e3cab",
+   "id": "c701546f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19fb87a4",
+   "id": "c1d16b38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "104ebb18",
+   "id": "7f5656d5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fac5fb0e",
+   "id": "3bbc89f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c44976c",
+   "id": "b5a71c2c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,12 +122,40 @@
     "    else:\n",
     "        # Manual segmentation does not exist. Run automatic segmentation.\n",
     "        print(f\"{subject}: Manual segmentation not found\")\n",
-    "        !sct_deepseg_sc -i \"{subject}_UNIT1.nii.gz\" -c t1 -qc \"{path_qc}\""
+    "        !sct_deepseg_sc -i \"{subject}_UNIT1.nii.gz\" -c t1 -qc \"{path_qc}\"\n",
+    "        \n",
+    "    # Dilate SC segmentation \n",
+    "    !sct_maths -i {subject}_UNIT1_seg.nii.gz -o {subject}_UNIT1_seg_dilated.nii.gz -dilate 15 -dim=2 -shape=disk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11ce5675",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Label vertebrae\n",
+    "\n",
+    "for subject in subjects:\n",
+    "    os.chdir(os.path.join(path_data, subject, \"anat\"))\n",
+    "    fname_manual_labels = os.path.join(path_labels, subject, \"anat\", f\"{subject}_UNIT1_label-disks_dseg.nii.gz\")\n",
+    "    if os.path.exists(fname_manual_labels):\n",
+    "        # Manual labels already exist. Copy file to local folder\n",
+    "        print(f\"{subject}: Manual labels found\\n\")\n",
+    "        shutil.copyfile(fname_manual_labels, f\"{subject}_UNIT1_seg_labeled_discs.nii.gz\") \n",
+    "        !sct_label_utils -i {subject}_UNIT1_seg.nii.gz -disc {subject}_UNIT1_seg_labeled_discs.nii.gz -o {subject}_UNIT1_seg_labeled.nii.gz\n",
+    "        # Generate QC report to assess labeled segmentation\n",
+    "        !sct_qc -i {subject}_UNIT1_seg.nii.gz -s {subject}_UNIT1_seg_labeled.nii.gz -p sct_label_vertebrae -qc {path_qc} -qc-subject {subject}\n",
+    "    else:\n",
+    "        # Manual labels do not exist. Run vertebrae labeling.\n",
+    "        print(f\"{subject}: Manual labels not found\")\n",
+    "        !sct_label_vertebrae -i {subject}_UNIT1.nii.gz -s {subject}_UNIT1_seg.nii.gz -c t1 -qc {path_qc} "
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "71bc2b69",
+   "id": "70f52598",
    "metadata": {},
    "source": [
     "## Process fmap/TFL (flip angle maps)"
@@ -134,7 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b90d297e",
+   "id": "847845a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce102c09",
+   "id": "ab0d9c08",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,13 +186,14 @@
     "\n",
     "for subject in subjects:\n",
     "    os.chdir(os.path.join(path_data, subject, \"fmap\"))\n",
-    "    !sct_apply_transfo -i ../anat/{subject}_UNIT1_seg.nii.gz -d {subject}_acq-anat_TB1TFL.nii.gz -w warp_{subject}_UNIT12{subject}_acq-anat_TB1TFL.nii.gz -x linear -o {subject}_acq-anat_TB1TFL_seg.nii.gz"
+    "    !sct_apply_transfo -i ../anat/{subject}_UNIT1_seg.nii.gz -d {subject}_acq-anat_TB1TFL.nii.gz -w warp_{subject}_UNIT12{subject}_acq-anat_TB1TFL.nii.gz -x linear -o {subject}_acq-anat_TB1TFL_seg.nii.gz\n",
+    "    !sct_apply_transfo -i ../anat/{subject}_UNIT1_seg_labeled.nii.gz -d {subject}_acq-anat_TB1TFL.nii.gz -w warp_{subject}_UNIT12{subject}_acq-anat_TB1TFL.nii.gz -x nn -o {subject}_acq-anat_TB1TFL_seg_labeled.nii.gz "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da756fa3",
+   "id": "979a3405",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,7 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24d4627d",
+   "id": "b18f5430",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,13 +250,13 @@
     "for subject in subjects:\n",
     "    os.chdir(os.path.join(path_data, subject, \"fmap\"))\n",
     "    fname_result_b1plus = os.path.join(path_results, f\"{subject}_TB1map.csv\")\n",
-    "    !sct_extract_metric -i {subject}_TB1map.nii.gz -f {subject}_acq-anat_TB1TFL_seg.nii.gz -method wa -perslice 1 -o \"{fname_result_b1plus}\""
+    "    !sct_extract_metric -i {subject}_TB1map.nii.gz -f {subject}_acq-anat_TB1TFL_seg_dilated.nii.gz -method wa -vert 3:9 -vertfile {subject}_acq-anat_TB1TFL_seg_labeled.nii.gz -perslice 1 -o \"{fname_result_b1plus}\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7357ec2e",
+   "id": "3df7c154",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,15 +290,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa02db9a",
+   "id": "e078fbb1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sites = [\"MGH\", \"MNI\", \"NYU\"]\n",
+    "sites = [\"MGH\", \"MNI\"]\n",
     "subject_names = [\"Subject D\", \"Subject L\", \"Subject R\"]\n",
     "\n",
     "fig = plt.figure()\n",
-    "gs = fig.add_gridspec(1, 3, wspace=0)\n",
+    "gs = fig.add_gridspec(1, 2, wspace=0)\n",
     "axs = gs.subplots(sharex=True, sharey=True)\n",
     "fig.set_size_inches(16, 6)\n",
     "\n",
@@ -295,18 +326,191 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "919f15b1",
+   "id": "6c9e3634",
    "metadata": {},
    "outputs": [],
    "source": [
-    "series = [b1_iqrs[i::3]for i in range(3)]\n",
-    "hline_x = np.array([0, 1, 2])\n",
+    "# Go back to root data folder\n",
+    "os.chdir(os.path.join(path_data))\n",
+    "\n",
+    "def smooth_data(data, window_size=20):\n",
+    "    \"\"\" Apply a simple moving average to smooth the data. \"\"\"\n",
+    "    return uniform_filter1d(data, size=window_size, mode='nearest')\n",
+    "\n",
+    "# Fixed grid for x-axis\n",
+    "x_grid = np.linspace(0, 1, 100)\n",
+    "\n",
+    "# z-slices corresponding to levels C3 to T2 on the PAM50 template. These will be used to scale the x-label of each subject.\n",
+    "original_vector = np.array([907, 870, 833, 800, 769, 735, 692, 646])\n",
+    "\n",
+    "# Normalize the PAM50 z-slice numbers to the 1-0 range (to show inferior-superior instead of superior-inferior)\n",
+    "min_val = original_vector.min()\n",
+    "max_val = original_vector.max()\n",
+    "normalized_vector = 1 - ((original_vector - min_val) / (max_val - min_val))\n",
+    "\n",
+    "# Use this normalized vector as x-ticks\n",
+    "custom_xticks = normalized_vector\n",
+    "\n",
+    "# Vertebral level labels\n",
+    "vertebral_levels = [\"C3\", \"C4\", \"C5\", \"C6\", \"C7\", \"T1\", \"T2\"]\n",
+    "# Calculate midpoints for label positions\n",
+    "label_positions = normalized_vector[:-1] + np.diff(normalized_vector) / 2\n",
+    "\n",
+    "# Number of sites determines the number of rows in the subplot\n",
+    "sites = [\"MGH\", \"MNI\"]\n",
+    "n_rows = len(sites)\n",
+    "\n",
+    "# Data storage for statistics\n",
+    "data_stats = []\n",
+    "\n",
+    "# Data storage for Plotly\n",
+    "b1_data_plotly = {}\n",
+    "\n",
+    "i = 0\n",
+    "j = 0\n",
+    "# Iterate over each site and create a subplot\n",
+    "for site in sites:\n",
+    "    \n",
+    "    b1_data_plotly[site]={}\n",
+    "    \n",
+    "    while i < (j+3):\n",
+    "        \n",
+    "        os.chdir(os.path.join(path_data, f\"{subjects[i]}\", \"fmap\"))\n",
+    "        \n",
+    "        # Initialize list to collect data for this subject\n",
+    "        subject_data = []\n",
+    "\n",
+    "        file_csv = os.path.join(path_results, f\"{subjects[i]}_TB1map.csv\")\n",
+    "        df = pd.read_csv(file_csv)\n",
+    "        wa_data = df['WA()']\n",
+    "\n",
+    "        # Normalize the x-axis to a 1-0 scale for each subject (to go from superior-inferior direction)\n",
+    "        x_subject = np.linspace(1, 0, len(wa_data))\n",
+    "\n",
+    "        # Interpolate to the fixed grid\n",
+    "        interp_func = interp1d(x_subject, wa_data, kind='linear', bounds_error=False, fill_value='extrapolate')\n",
+    "        resampled_data = interp_func(x_grid)\n",
+    "\n",
+    "        # Apply smoothing\n",
+    "        smoothed_data = smooth_data(resampled_data)\n",
+    "\n",
+    "        subject_data.append(smoothed_data)\n",
+    "\n",
+    "        # If there's data for this shim method, plot it\n",
+    "        if subject_data:\n",
+    "            # Plotting each file's data separately\n",
+    "            for resampled_data in subject_data:\n",
+    "                b1_data_plotly[site][subjects[i]]=resampled_data\n",
+    "\n",
+    "            # Compute stats on the non-resampled data (to avoid interpolation errors)\n",
+    "            mean_data = np.mean(wa_data)\n",
+    "            sd_data = np.std(wa_data)\n",
+    "            #data_stats.append([site, subjects[i], mean_data, sd_data])\n",
+    "            data_stats.append([site, subjects[i], sd_data])\n",
+    "        else:\n",
+    "            b1_data_plotly[site][subjects[i]]=None\n",
+    "        \n",
+    "        i += 1\n",
+    "        \n",
+    "    j += 3\n",
+    "    \n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d343fb31",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "sites = [\"MGH\", \"MNI\"]\n",
+    "subject_names = [\"Subject D\", \"Subject L\", \"Subject R\"]\n",
+    "\n",
+    "fig = plt.figure()\n",
+    "gs = fig.add_gridspec(1, 2, wspace=0)\n",
+    "axs = gs.subplots(sharex=True, sharey=True)\n",
+    "fig.set_size_inches(16, 6)\n",
+    "\n",
+    "    \n",
+    "j = 0\n",
+    "i = 0\n",
+    "for k, site in enumerate(sites):    \n",
+    "    while i < (j+3):\n",
+    "        axs[k].plot(b1_data_plotly[site][subjects[i]])\n",
+    "        axs[k].set_title(sites[k])\n",
+    "        axs[k].grid()\n",
+    "        i += 1\n",
+    "    j += 3\n",
+    "    \n",
+    "axs[0].legend(subject_names,loc=\"upper right\")\n",
+    "           \n",
+    "           \n",
+    "for ax in axs.flat:\n",
+    "    ax.set(xlabel='Vertebral Levels', ylabel='B1+ efficiency [nT/V]', xticks=100*label_positions, xticklabels=vertebral_levels)\n",
+    "\n",
+    "# Hide x labels and tick labels for top plots and y ticks for right plots.\n",
+    "for ax in axs.flat:\n",
+    "    ax.label_outer()\n",
+    "\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f07109d",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "series = [data_stats[i::len(subject_names)] for i in range(len(subject_names))]\n",
+    "hline_x = np.array([0, 1])\n",
+    "hline_width = 0.25\n",
+    "\n",
+    "sub_sd = np.zeros((len(subject_names),len(sites)))\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "\n",
+    "i = 0 \n",
+    "for subject_name, subject_series in zip(subject_names, series):    \n",
+    "    ax.scatter(sites, [subject_series[k][2] for k in range(0,len(sites))], label=subject_name)\n",
+    "    \n",
+    "    for j in range(len(sites)):\n",
+    "        sub_sd[i][j] = subject_series[j][2]\n",
+    "    \n",
+    "    i+=1\n",
+    "    \n",
+    "plt.hlines(np.mean(sub_sd, axis=0),hline_x - hline_width/2, hline_x + hline_width/2, color=\"black\", label=\"Across subj. mean\")\n",
+    "\n",
+    "\n",
+    "ax.legend()\n",
+    "ax.set_ylim(2, 8)\n",
+    "ax.set_title(\"SD B1+: standard deviation across slices of SC-averaged signal\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f01f7fad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "series = [b1_iqrs[i::3] for i in range(3)]\n",
+    "hline_x = np.array([0, 1])\n",
     "hline_width = 0.25\n",
     "\n",
     "fig, ax = plt.subplots()\n",
     "for subject_name, subject_series in zip(subject_names, series):\n",
     "    ax.scatter(sites, subject_series, label=subject_name)\n",
-    "plt.hlines([np.mean(b1_iqrs[i:i+3]) for i in range(0, len(b1_iqrs), 3)], hline_x - hline_width/2, hline_x + hline_width/2, color=\"black\", label=\"Across subj. mean\")\n",
+    "plt.hlines([np.mean(b1_iqrs[i:i+2]) for i in range(0, len(b1_iqrs), 3)], hline_x - hline_width/2, hline_x + hline_width/2, color=\"black\", label=\"Across subj. mean\")\n",
     "ax.legend()\n",
     "ax.set_ylim(2, 20)\n",
     "ax.set_title(\"IQR B1+: IQR across slices within SC ROI\")\n",
@@ -316,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29cdf4b3",
+   "id": "bdaba103",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
I have made adjustments to the B1+ mapping visualization. 

The figure showing B1+ efficiency along the cord for all subjects now re-uses a lot of the code from https://github.com/shimming-toolbox/rf-shimming-7t/blob/main/content/index.ipynb so that B1+ can be plot for C3-T2
![fig1](https://github.com/spinal-cord-7t/coil-qc-code/assets/6652194/a7e67dd0-6b84-44bd-b625-58ec76dc1c17)

The figure showing the standard deviation along the cord now uses the same data structures as those which are created for the B1+ along cord figure. 
![fig2](https://github.com/spinal-cord-7t/coil-qc-code/assets/6652194/044848cf-68a8-493e-9d0a-73376e11aae9)

The notebook has been tested with data from MGH and MNI sites using manually corrected SC segmentations and vertebral labels.