### PR TITLE
Generate approximate mask of spinal cord

### DIFF
--- a/data_processing-phantom.ipynb
+++ b/data_processing-phantom.ipynb
@@ -282,12 +282,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "os.chdir(os.path.join(path_data, \"sub-CRMBM\", \"fmap\"))\n",
+    "\n",
     "# Create labels along an approximate spinal cord\n",
-    "sct_label_utils -i sub-CRMBM_acq-anat_TB1TFL.nii.gz -create 49,108,23,1:49,99,23,1:49,88,23,1:50,76,23,1:55,63,23,1:62,51,23,1:68,35,23,1:72,26,23,1 -o label_cord.nii.gz\n",
+    "! sct_label_utils -i \"sub-CRMBM_acq-anat_TB1TFL.nii.gz\" -create 49,108,23,1:49,99,23,1:49,88,23,1:50,76,23,1:55,63,23,1:62,51,23,1:68,35,23,1:72,26,23,1 -o \"label_cord.nii.gz\"\n",
     "# Create spinal cord centerline\n",
-    "sct_get_centerline -i label_cord.nii.gz -method fitseg -o centerline_spinalcord.nii.gz\n",
+    "! sct_get_centerline -i \"label_cord.nii.gz\" -method fitseg -o \"centerline_spinalcord.nii.gz\"\n",
     "# Create mask of 10mm diameter around centerline\n",
-    "sct_create_mask -i sub-CRMBM_acq-anat_TB1TFL.nii.gz -p centerline,centerline_spinalcord.nii.gz -size 10mm -f cylinder -o mask_spinalcord.nii.gz"
+    "! sct_create_mask -i \"sub-CRMBM_acq-anat_TB1TFL.nii.gz\" -p centerline,\"centerline_spinalcord.nii.gz\" -size 10mm -f cylinder -o \"mask_spinalcord.nii.gz\""
    ]
   },
   {
@@ -662,7 +664,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/data_processing-phantom.ipynb
+++ b/data_processing-phantom.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "a2388d2a",
    "metadata": {},
    "outputs": [],
@@ -59,19 +59,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "464b00b7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "path_data: /Users/julien/code/coil-qc-code/data-phantom/sub-UCL/fmap/data-phantom/\n",
-      "subjects: []\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define useful variables\n",
     "path_data = os.path.join(os.getcwd(), \"data-phantom/\")\n",
@@ -273,17 +264,21 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "16564ce0",
+   "cell_type": "markdown",
+   "id": "787b1750",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## Generate approximate mask of spinal cord\n",
+    "\n",
+    "The purpose of this section is to generate an approximate mask of the spinal cord that will be used to quantify B1+ values inside the phantom. To do this, we identified a representative human subject, overlaid it on the anthropomorphic phantom, created a few pointwise labels along the spinal cord, interpolated those points using bsplines, and then created a cylindrical mask of 10mm diameter along the generated centerline.\n",
+    "\n",
+    "![image](https://private-user-images.githubusercontent.com/2482071/337944437-e101a816-d0d8-454b-a6e3-240deecbd0d1.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTc5MDMzNDAsIm5iZiI6MTcxNzkwMzA0MCwicGF0aCI6Ii8yNDgyMDcxLzMzNzk0NDQzNy1lMTAxYTgxNi1kMGQ4LTQ1NGItYTZlMy0yNDBkZWVjYmQwZDEucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDYwOSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA2MDlUMDMxNzIwWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9ZjQ1OWI5MGVkZTFjZDEzMjYwZGMwMGFjNjg3NjcxYjVlZDhhMDQ3N2FhYzI3MTFmYjM3Yzk2NWQwMzQzOTlhZiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.dxIWub23KpBv8jIlZIfdn8QdL3hLBfYLwwLON5gSiis)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f855446b",
+   "id": "81b17684",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/data_processing-phantom.ipynb
+++ b/data_processing-phantom.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "a2388d2a",
    "metadata": {},
    "outputs": [],
@@ -59,10 +59,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "464b00b7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "path_data: /Users/julien/code/coil-qc-code/data-phantom/sub-UCL/fmap/data-phantom/\n",
+      "subjects: []\n"
+     ]
+    }
+   ],
    "source": [
     "# Define useful variables\n",
     "path_data = os.path.join(os.getcwd(), \"data-phantom/\")\n",
@@ -261,6 +270,29 @@
     "    # Save B1 map in [T/V] as NIfTI file\n",
     "    nii_b1 = nib.Nifti1Image(b1_map, nii.affine, nii.header)\n",
     "    nib.save(nii_b1, f\"{subject}_TFLTB1map.nii.gz\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16564ce0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f855446b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create labels along an approximate spinal cord\n",
+    "sct_label_utils -i sub-CRMBM_acq-anat_TB1TFL.nii.gz -create 49,108,23,1:49,99,23,1:49,88,23,1:50,76,23,1:55,63,23,1:62,51,23,1:68,35,23,1:72,26,23,1 -o label_cord.nii.gz\n",
+    "# Create spinal cord centerline\n",
+    "sct_get_centerline -i label_cord.nii.gz -method fitseg -o centerline_spinalcord.nii.gz\n",
+    "# Create mask of 10mm diameter around centerline\n",
+    "sct_create_mask -i sub-CRMBM_acq-anat_TB1TFL.nii.gz -p centerline,centerline_spinalcord.nii.gz -size 10mm -f cylinder -o mask_spinalcord.nii.gz"
    ]
   },
   {


### PR DESCRIPTION
Method to generate approximate spinal cord is illustrated below:

![Screenshot 2024-06-08 at 11 13 37 PM](https://github.com/spinal-cord-7t/coil-qc-code/assets/2482071/e101a816-d0d8-454b-a6e3-240deecbd0d1)

The source of the figure is available here: [phantom_mask_creation.zip](https://github.com/user-attachments/files/15750425/phantom_mask_creation.zip)


Fixes #71